### PR TITLE
Preventing failure of the entire workflow if a single cluster fails

### DIFF
--- a/.github/workflows/loadtest-hourly.yaml
+++ b/.github/workflows/loadtest-hourly.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   load_test:
     strategy:
+      fail-fast: false
       matrix:
         cluster:
           - label: stone-prd-rh01
@@ -15,16 +16,19 @@ jobs:
             member_cluster_secret: MEMBER_CLUSTER_STONE_PRD_RH01
             ocp_prometheus_token_secret: OCP_PROMETHEUS_TOKEN_STONE_PRD_RH01
             users_secret: USERS_STONE_PRD_RH01
+            should_fail: false
           - label: stone-stg-rh01
             repo: https://github.com/rhtap-perf-test/nodejs-devfile-sample2
             member_cluster_secret: MEMBER_CLUSTER_STONE_STG_RH01
             ocp_prometheus_token_secret: OCP_PROMETHEUS_TOKEN_STONE_STG_RH01
             users_secret: USERS_STONE_STG_RH01
+            should_fail: false
           - label: kflux-prd-rh02
             repo: https://github.com/rhtap-perf-test/nodejs-devfile-sample3
             member_cluster_secret: MEMBER_CLUSTER_KFLUX_PRD_RH02
             ocp_prometheus_token_secret: OCP_PROMETHEUS_TOKEN_KFLUX_PRD_RH02
             users_secret: USERS_KFLUX_PRD_RH02
+            should_fail: false
 
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/loadtest-hourly.yaml
+++ b/.github/workflows/loadtest-hourly.yaml
@@ -28,6 +28,8 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # continue even if the job fails
+    continue-on-error: true
 
     # Make sure this action does not get scheduled by cron on e2e-tests forks
     if: ${{ github.repository_owner == 'konflux-ci' || github.event_name != 'schedule' }}


### PR DESCRIPTION
This PR ensures that all cluster jobs continue running even if a step fails in one of them, by disabling fail-fast. Additionally, it introduces a way to control whether a failure in a specific cluster should cause the entire workflow to fail or not.