### PR TITLE
Adding Error deleting on-pull-request default PipelineRun

### DIFF
--- a/tests/load-tests/errors.py
+++ b/tests/load-tests/errors.py
@@ -64,6 +64,7 @@ FAILED_PLR_ERRORS = {
     "Failed because registry.access.redhat.com returned 503 when reading manifest": r"source-build:ERROR:command execution failure, status: 1, stderr: time=.* level=fatal msg=.Error parsing image name .* reading manifest .* in registry.access.redhat.com/.* received unexpected HTTP status: 503 Service Unavailable",
     "RPM build failed: bool cannot be defined via typedef": r"error: .bool. cannot be defined via .typedef..*error: Bad exit status from /var/tmp/rpm-tmp..* ..build.",
     "skip": r"skipping step because a previous step failed",
+    "unexpected end of JSON input" : r"Error parsing image name .* unexpected end of JSON input .*",
 }
 
 


### PR DESCRIPTION
Hi @jhutar  as per your recording, I have added a new Pipeline fail error.  This is the error logs. Thanks for making it easier to understand :+1: https://workdir-exporter-jenkins-csb-perf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/workspace/StoneSoupLoadTestProbe_stone_prd_rh01/e2e-tests/tests/load-tests/OLD/run-stone-prd-rh01-2025_07_01T19_17_10_668176918_00_00/collected-data/jhutar-1-tenant/1/pod-jhutar-1-app-ghefc-comp-0-oe35b8003686447efeb763c670815dd4c-pod-step-build.log 

Found it here as well https://workdir-exporter-jenkins-csb-perf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/workspace/StoneSoupLoadTestProbe_stone_stg_rh01/e2e-tests/tests/load-tests/OLD/run-stone-stg-rh01-2025_07_01T19_09_11_194618807_00_00/collected-data/jhutar-tenant/1/pod-jhutar-app-slywe-comp-0-on-push-dqq9b-build-container-pod-step-build.log