### PR TITLE
Adding Pipeline run failures: Error allocating hosts and others

### DIFF
--- a/tests/load-tests/errors.py
+++ b/tests/load-tests/errors.py
@@ -57,16 +57,19 @@ ERRORS = {
 }
 
 FAILED_PLR_ERRORS = {
+    "Can not find chroot_scan.tar.gz file": r"tar: .*/chroot_scan.tar.gz: Cannot open: No such file or directory",
     "DNF failed to download repodata from Koji": r"ERROR Command returned error: Failed to download metadata (baseurl: \"https://kojipkgs.fedoraproject.org/repos/[^ ]*\") for repository \"build\": Usable URL not found",
     "Error allocating host as provision TR already exists": r"Error allocating host: taskruns.tekton.dev \".*provision\" already exists",
-    "Error creating build container: 403 Forbidden": r"Error: creating build container .* 403 Forbidden .*",
+    "Error cannot find Dockerfile": r"Cannot find Dockerfile Dockerfile .*",
+    "Error creating build containter: 403 forbidden": r"internal error: unable to copy from source .* 403 Forbidden .*",
+    "Error in configuration - option config_opts['root'] must be present in your config" : r"option config_opts['root'] must be present in your config .*",
     "Failed because of quay.io returned 502": r"level=fatal msg=.Error parsing image name .*docker://quay.io/.* Requesting bearer token: invalid status code from registry 502 .Bad Gateway.",
     "Failed because registry.access.redhat.com returned 503 when reading manifest": r"source-build:ERROR:command execution failure, status: 1, stderr: time=.* level=fatal msg=.Error parsing image name .* reading manifest .* in registry.access.redhat.com/.* received unexpected HTTP status: 503 Service Unavailable",
+    "Introspection failed because of incomplete .docker/config.json": r".* level=fatal msg=\"Error parsing image name .*: getting username and password: reading JSON file .*/tekton/home/.docker/config.json.*: unmarshaling JSON at .*: unexpected end of JSON input\"",
     "RPM build failed: bool cannot be defined via typedef": r"error: .bool. cannot be defined via .typedef..*error: Bad exit status from /var/tmp/rpm-tmp..* ..build.",
-    "skip": r"skipping step because a previous step failed",
-    "unexpected end of JSON input" : r"Error parsing image name .* unexpected end of JSON input .*",
+    "SKIP": r"Skipping step because a previous step failed",
+    "buildah build failed creating build container: registry.access.redhat.com returned 403": r"Error: creating build container: internal error: unable to copy from source docker://registry.access.redhat.com/.*: copying system image from manifest list: determining manifest MIME type for docker://registry.access.redhat.com/.*: reading manifest .* in registry.access.redhat.com/.*: StatusCode: 403",
 }
-
 
 def message_to_reason(reasons_and_errors: dict, msg: str) -> str | None:
     """

--- a/tests/load-tests/errors.py
+++ b/tests/load-tests/errors.py
@@ -59,7 +59,7 @@ ERRORS = {
 FAILED_PLR_ERRORS = {
     "DNF failed to download repodata from Koji": r"ERROR Command returned error: Failed to download metadata (baseurl: \"https://kojipkgs.fedoraproject.org/repos/[^ ]*\") for repository \"build\": Usable URL not found",
     "Error allocating host as provision TR already exists": r"Error allocating host: taskruns.tekton.dev \".*provision\" already exists",
-    "Error creating build container: 403 Forbidden": r"unable to copy from source .* 403 Forbidden .*",
+    "Error creating build container: 403 Forbidden": r"Error: creating build container .* 403 Forbidden .*",
     "Failed because of quay.io returned 502": r"level=fatal msg=.Error parsing image name .*docker://quay.io/.* Requesting bearer token: invalid status code from registry 502 .Bad Gateway.",
     "Failed because registry.access.redhat.com returned 503 when reading manifest": r"source-build:ERROR:command execution failure, status: 1, stderr: time=.* level=fatal msg=.Error parsing image name .* reading manifest .* in registry.access.redhat.com/.* received unexpected HTTP status: 503 Service Unavailable",
     "RPM build failed: bool cannot be defined via typedef": r"error: .bool. cannot be defined via .typedef..*error: Bad exit status from /var/tmp/rpm-tmp..* ..build.",

--- a/tests/load-tests/errors.py
+++ b/tests/load-tests/errors.py
@@ -64,6 +64,7 @@ FAILED_PLR_ERRORS = {
     "Failed because registry.access.redhat.com returned 503 when reading manifest": r"source-build:ERROR:command execution failure, status: 1, stderr: time=.* level=fatal msg=.Error parsing image name .* reading manifest .* in registry.access.redhat.com/.* received unexpected HTTP status: 503 Service Unavailable",
     "RPM build failed: bool cannot be defined via typedef": r"error: .bool. cannot be defined via .typedef..*error: Bad exit status from /var/tmp/rpm-tmp..* ..build.",
     "skip": r"skipping step because a previous step failed",
+    "unexpected end of JSON input" : r"Error parsing image name .* unexpected end of JSON input .*",
 }
 
 

--- a/tests/load-tests/errors.py
+++ b/tests/load-tests/errors.py
@@ -18,7 +18,7 @@ COLUMN_MESSAGE = 2
 # Errors patterns we recognize (when newlines were removed)
 ERRORS = {
     "Application creation timed out waiting for quota evaluation": r"Application failed creation: Unable to create the Application .*: Internal error occurred: resource quota evaluation timed out",
-    "Build Pipeline Run was cancelled" : r"Build Pipeline Run failed run: PipelineRun for component [\w-]+ in namespace [\w-]+ failed: .* Reason:Cancelled .* Message:PipelineRun .* was cancelled",
+    "Build Pipeline Run was cancelled" : r"Build Pipeline Run failed run: PipelineRun for component .* in namespace .* failed: .*",
     "Component creation timed out waiting for image-controller annotations": r"Component failed creation: Unable to create the Component .* timed out when waiting for image-controller annotations to be updated on component",
     "Couldnt get pipeline via bundles resolver from quay.io due to 429": r"Message:Error retrieving pipeline for pipelinerun .*bundleresolver.* cannot retrieve the oci image: GET https://quay.io/v2/.*unexpected status code 429 Too Many Requests",
     "Couldnt get pipeline via git resolver from gitlab.cee due to 429": r"Message:.*resolver failed to get Pipeline.*error requesting remote resource.*Git.*https://gitlab.cee.redhat.com/.* status code: 429",
@@ -26,6 +26,7 @@ ERRORS = {
     "Couldnt get task via buldles resolver from quay.io due to 429": r"Message:.*Couldn't retrieve Task .*resolver type bundles.*https://quay.io/.* status code 429 Too Many Requests",
     "Couldnt get task via git resolver from gitlab.cee due to 429": r"Message:.*Couldn't retrieve Task .*resolver type git.*https://gitlab.cee.redhat.com/.* status code: 429",
     "Couldnt get task via http resolver from gitlab.cee": r"Message:.*Couldn't retrieve Task .*resolver type http.*error getting.*requested URL .*https://gitlab.cee.redhat.com/.* is not found",
+    "Error deleting on-pull-request default PipelineRun": r"Repo-templating workflow component cleanup failed: Error deleting on-pull-request default PipelineRun in namespace .*: Unable to list PipelineRuns for component .* in namespace .*: context deadline exceeded",
     "Failed Integration test scenario when calling dintegrationtestscenario.kb.io webhook": r"Integration test scenario failed creation: Unable to create the Integration Test Scenario .*: Internal error occurred: failed calling webhook .*dintegrationtestscenario.kb.io.*: failed to call webhook: Post .*https://integration-service-webhook-service.integration-service.svc:443/mutate-appstudio-redhat-com-v1beta2-integrationtestscenario.*: no endpoints available for service .*integration-service-webhook-service",
     "Failed application creation when calling mapplication.kb.io webhook": r"Application failed creation: Unable to create the Application .*: Internal error occurred: failed calling webhook .*mapplication.kb.io.*: failed to call webhook: Post .*https://application-service-webhook-service.application-service.svc:443/mutate-appstudio-redhat-com-v1alpha1-application.* no endpoints available for service .*application-service-webhook-service",
     "Failed component creation because resource quota evaluation timed out": r"Component failed creation: Unable to create the Component .*: Internal error occurred: resource quota evaluation timed out",
@@ -38,6 +39,7 @@ ERRORS = {
     "GitLab token used by test expired": r"Repo forking failed: Error deleting project .*: DELETE https://gitlab.cee.redhat.com/.*: 401 .*error: invalid_token.*error_description: Token is expired. You can either do re-authorization or token refresh",
     "Pipeline failed": r"Message:Tasks Completed: [0-9]+ \(Failed: [1-9]+,",
     "Post-test data collection failed": r"Failed to collect pipeline run JSONs",
+    "Release failure: PipelineRun not created": r"couldn't find PipelineRun in managed namespace '%s' for a release '%s' in '%s' namespace",
     "Repo forking failed as GitLab CEE says 401 Unauthorized": r"Repo forking failed: Error deleting project .*: DELETE https://gitlab.cee.redhat.com/.*: 401 .*message: 401 Unauthorized.*",
     "Repo forking failed as the target is still being deleted": r"Repo forking failed: Error forking project .* POST https://gitlab.cee.redhat.com.* 409 .*Project namespace name has already been taken, The project is still being deleted",
     "Repo forking failed because gitlab.com returned 503": r"Repo forking failed: Error checking repository .*: GET https://api.github.com/repos/.*: 503 No server is currently available to service your request. Sorry about that. Please try resubmitting your request and contact us if the problem persists.*",
@@ -55,12 +57,13 @@ ERRORS = {
 }
 
 FAILED_PLR_ERRORS = {
-    "SKIP": r"Skipping step because a previous step failed",
     "DNF failed to download repodata from Koji": r"ERROR Command returned error: Failed to download metadata (baseurl: \"https://kojipkgs.fedoraproject.org/repos/[^ ]*\") for repository \"build\": Usable URL not found",
     "Error allocating host as provision TR already exists": r"Error allocating host: taskruns.tekton.dev \".*provision\" already exists",
+    "Error creating build container: 403 Forbidden": r"unable to copy from source .* 403 Forbidden .*",
     "Failed because of quay.io returned 502": r"level=fatal msg=.Error parsing image name .*docker://quay.io/.* Requesting bearer token: invalid status code from registry 502 .Bad Gateway.",
     "Failed because registry.access.redhat.com returned 503 when reading manifest": r"source-build:ERROR:command execution failure, status: 1, stderr: time=.* level=fatal msg=.Error parsing image name .* reading manifest .* in registry.access.redhat.com/.* received unexpected HTTP status: 503 Service Unavailable",
     "RPM build failed: bool cannot be defined via typedef": r"error: .bool. cannot be defined via .typedef..*error: Bad exit status from /var/tmp/rpm-tmp..* ..build.",
+    "skip": r"skipping step because a previous step failed",
 }
 
 


### PR DESCRIPTION
   Hi @jhutar I have found the following pipeline run failure https://workdir-exporter-jenkins-csb-perf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/workspace/StoneSoupLoadTestProbe_stone_prod_p02_RPM/e2e-tests/tests/load-tests/OLD/run-stone-prod-p02-2025_07_03T16_35_49_006538124_00_00/collected-data/jhutar-tenant/1/pod-jhutar-app-lpgau-comp-0-on-push-t5r9s-calculate-deps-x86-64-pod-step-mock-build.log 

https://workdir-exporter-jenkins-csb-perf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/workspace/StoneSoupLoadTestProbe_stone_prd_rh01_RPM/e2e-tests/tests/load-tests/OLD/run-stone-prd-rh01-2025_07_02T04_44_11_452032869_00_00/collected-data/jhutar-1-tenant/1/pod-jhutar-1-app-mpmwq-comp-0-oe9a20e1dc37acfee91607c043edc5053-pod-step-mock-build.log

https://workdir-exporter-jenkins-csb-perf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/workspace/StoneSoupLoadTestProbe_kflux_rhel_p01_RPM/e2e-tests/tests/load-tests/OLD/run-kflux-rhel-p01-2025_07_03T11_39_39_192503922_00_00/collected-data/jhutar-tenant/1/pod-jhutar-app-svayh-comp-0-on-push-2wvnb-build-container-pod-step-build.log