### PR TITLE
feat(load-tests): step- prefix and task-name metric storage

### DIFF
--- a/docs/LoadTests.md
+++ b/docs/LoadTests.md
@@ -4,13 +4,12 @@
 
 When load-test results are collected (e.g. by `collect-results-probe.sh`), the following happens:
 
-1. **POD and step parsing**  
-   A shell pipeline (find + jq) scans `ARTIFACT_DIR/collected-data/` for `collected-taskrun-*.json` files. From each TaskRun JSON it reads `.metadata.namespace`, `.status.podName`, and `.status.steps[].name`, then aggregates into:
-   - `ARTIFACT_DIR/get-pod-step-names.json` – machine-readable list of `{ "pods": [ { "namespace", "pod_id", "steps": [...] }, ... ] }`
+1. **POD, task and step parsing**  
+   A shell pipeline (find + jq) scans `ARTIFACT_DIR/collected-data/` for `collected-taskrun-*.json` files. From each TaskRun JSON it reads `.metadata.namespace`, `.status.podName`, `.metadata.name` (task name), and `.status.steps[].name`, then aggregates into:
+   - `ARTIFACT_DIR/get-pod-step-names.json` – machine-readable list of `{ "pods": [ { "namespace", "pod_id", "task_name", "steps": [...] }, ... ] }`
 
 2. **Monitoring config expansion**  
-   `ci-scripts/utility_scripts/append-pod-step-monitoring.py` reads the repo’s `cluster_read_config.yaml` (from the script’s path) and `get-pod-step-names.json`, then appends one `monitor_pod_container(namespace, pod_id, step, ...)` Jinja call per (POD, step).
-   - The result is written to `ARTIFACT_DIR/cluster_read_config.yaml_modified`, which is then used for Prometheus monitoring collection (per-pod, per-container CPU and working-set memory).
+   `ci-scripts/utility_scripts/append-pod-step-monitoring.py` reads the repo’s `cluster_read_config.yaml` and `get-pod-step-names.json`, then appends one `monitor_task_step(namespace, pod_id, task_name, step_name, ...)` Jinja call per (task, step). Metrics are stored under **task name** (stable across runs) as `measurements.tasks[<task_name>].step[<step_name>].memory` and `.cpu`. The Prometheus query uses container name `step-<step_name>` to match Tekton step containers.
 
 3. **Artifacts produced**  
    Under each run’s `ARTIFACT_DIR`: `get-pod-step-names.json`, `cluster_read_config.yaml_modified`.

--- a/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
+++ b/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
@@ -177,6 +177,17 @@
   monitoring_step: {{ step }}
 {%- endmacro %}
 
+{# Per-task, per-step metrics: use task name (stable across runs) and step- prefix for Tekton step containers #}
+{% macro monitor_task_step(namespace, pod, task_name, step_name, step=15, pod_suffix_regex='-[0-9a-f]+-.*') -%}
+# Task step (container name in cluster is step-<step_name>)
+- name: measurements.tasks[{{ task_name }}].step[{{ step_name }}].memory
+  monitoring_query: sum(container_memory_working_set_bytes{namespace='{{ namespace }}', pod=~'{{ pod }}{{ pod_suffix_regex }}', container='step-{{ step_name }}'})
+  monitoring_step: {{ step }}
+- name: measurements.tasks[{{ task_name }}].step[{{ step_name }}].cpu
+  monitoring_query: sum(irate(container_cpu_usage_seconds_total{namespace='{{ namespace }}', pod=~'{{ pod }}{{ pod_suffix_regex }}', container='step-{{ step_name }}'}[5m]))
+  monitoring_step: {{ step }}
+{%- endmacro %}
+
 {{ monitor_pod('openshift-pipelines', 'tekton-pipelines-controller', 15) }}
 {{ monitor_pod('tekton-results', 'tekton-results-watcher', 1, '-.*') }}
 {{ monitor_pod('openshift-etcd', 'etcd', 15, pod_suffix_regex='-ip-.+') }}

--- a/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
@@ -42,16 +42,16 @@ mv "${ARTIFACT_DIR}/output.svg" "${ARTIFACT_DIR}/show-pipelines.svg" || true
 echo "[$(date --utc -Ins)] Computing duration of PRs, TRs and steps"
 ci-scripts/utility_scripts/get-taskruns-durations.py --debug --data-dir "${ARTIFACT_DIR}" --dump-json "${ARTIFACT_DIR}/get-taskruns-durations.json" &>"${ARTIFACT_DIR}/get-taskruns-durations.log"
 
-echo "[$(date --utc -Ins)] Parsing POD and step names from collected-taskrun JSON"
+echo "[$(date --utc -Ins)] Parsing POD, task and step names from collected-taskrun JSON"
 CD="${ARTIFACT_DIR}/collected-data"
 if [[ -d "$CD" ]]; then
   find "$CD" -name 'collected-taskrun-*.json' -exec jq -r '
-    .metadata.namespace as $ns | .status.podName as $pod |
-    (.status.steps // [])[]? | [$ns, $pod, .name] | @tsv
+    .metadata.namespace as $ns | .status.podName as $pod | .metadata.name as $task |
+    (.status.steps // [])[]? | [$ns, $pod, $task, .name] | @tsv
   ' {} \; 2>/dev/null | sort -u -t$'\t' | jq -R -s '
     split("\n") | map(select(length>0) | split("\t")) |
     group_by(.[0] + "\t" + .[1]) |
-    map({"namespace": .[0][0], "pod_id": .[0][1], "steps": map(.[2])}) |
+    map({"namespace": .[0][0], "pod_id": .[0][1], "task_name": .[0][2], "steps": map(.[3])}) |
     sort_by(.namespace + .pod_id) |
     {pods: .}
   ' > "${ARTIFACT_DIR}/get-pod-step-names.json" 2>/dev/null || true
@@ -60,7 +60,7 @@ if [[ ! -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]]; then
   echo '{"pods":[]}' > "${ARTIFACT_DIR}/get-pod-step-names.json"
 fi
 
-echo "[$(date --utc -Ins)] Appending dynamic monitor_pod_container entries and saving as cluster_read_config.yaml_modified"
+echo "[$(date --utc -Ins)] Appending dynamic monitor_task_step entries and saving as cluster_read_config.yaml_modified"
 if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]] && jq -e '.pods | length > 0' "${ARTIFACT_DIR}/get-pod-step-names.json" >/dev/null 2>&1; then
     python3 ci-scripts/utility_scripts/append-pod-step-monitoring.py \
         --pod-step-json "${ARTIFACT_DIR}/get-pod-step-names.json" \

--- a/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
+++ b/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
 """
-Append monitor_pod_container() Jinja lines to cluster_read_config.yaml
-from get-pod-step-names.json. One line per (namespace, pod_id, step).
+Append monitor_task_step() Jinja lines to cluster_read_config.yaml
+from get-pod-step-names.json. One line per (namespace, pod_id, task_name, step).
+Metrics are stored under task name (stable across runs); Prometheus query uses step-<step> for container.
 """
 
 import argparse
 import json
 import os
+import re
+
+
+def sanitize_task_name(name):
+    """Sanitize task name for use in metric path (replace / and . with -)."""
+    if not name:
+        return name
+    return re.sub(r"[/.]", "-", name)
 
 
 def main():
@@ -28,16 +37,17 @@ def main():
     for entry in data.get("pods", []):
         ns = entry["namespace"]
         pod_id = entry["pod_id"]
+        task_name = sanitize_task_name(entry.get("task_name", pod_id))
         for step in entry["steps"]:
             lines.append(
-                "{{ monitor_pod_container('%s', '%s', '%s', %s, '%s') }}"
-                % (ns, pod_id, step, args.step_default, args.pod_suffix_regex)
+                "{{ monitor_task_step('%s', '%s', '%s', '%s', %s, '%s') }}"
+                % (ns, pod_id, task_name, step, args.step_default, args.pod_suffix_regex)
             )
 
     with open(input_yaml) as f:
         content = f.read()
 
-    suffix = "\n# Dynamic POD/step monitoring (from parsed collected-data)\n"
+    suffix = "\n# Dynamic task/step monitoring (from parsed collected-data; stored under task name)\n"
     suffix += "\n".join(lines)
     suffix += "\n"
 


### PR DESCRIPTION
- Add monitor_task_step macro: Prometheus query uses container= 'step-<step_name>' so Tekton step containers are matched; metrics stored under measurements.tasks[<task_name>].step[<step_name>].
- Parse task_name from collected-taskrun JSON (.metadata.name) in collect-results-probe.sh jq pipeline; include in get-pod-step-names.json.
- append-pod-step-monitoring.py: emit monitor_task_step() calls with task_name (sanitized for path); keep backward compat if task_name missing.
- Docs: LoadTests.md updated; add LOADTEST_MONITORING_CHANGES_EXAMPLES.md with before/after examples from real run artifacts.

Fixes monitoring "missing response" for pipeline steps (container label is step-build not build). Enables cross-run comparison by task name.


Assisted-by: Cursor-Agent@cursor.com