### PR TITLE
fix(load-tests): address PR #82 review comments

### DIFF
--- a/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
+++ b/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
@@ -177,7 +177,7 @@
   monitoring_step: {{ step }}
 {%- endmacro %}
 
-{# Per-task, per-step metrics: use task name (stable across runs) and step- prefix for Tekton step containers #}
+{# Per task, per step metrics: use task name (stable across runs) and step- prefix for Tekton step containers #}
 {% macro monitor_task_step(namespace, pod, task_name, step_name, step=15, pod_suffix_regex='-[0-9a-f]+-.*') -%}
 # Task step (container name in cluster is step-<step_name>)
 - name: measurements.tasks[{{ task_name }}].step[{{ step_name }}].memory

--- a/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
+++ b/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
@@ -8,14 +8,6 @@ Metrics are stored under task name (stable across runs); Prometheus query uses s
 import argparse
 import json
 import os
-import re
-
-
-def sanitize_task_name(name):
-    """Sanitize task name for use in metric path (replace / and . with -)."""
-    if not name:
-        return name
-    return re.sub(r"[/.]", "-", name)
 
 
 def main():
@@ -37,7 +29,7 @@ def main():
     for entry in data.get("pods", []):
         ns = entry["namespace"]
         pod_id = entry["pod_id"]
-        task_name = sanitize_task_name(entry.get("task_name", pod_id))
+        task_name = entry.get("task_name", pod_id)
         for step in entry["steps"]:
             lines.append(
                 "{{ monitor_task_step('%s', '%s', '%s', '%s', %s, '%s') }}"


### PR DESCRIPTION
- Use task name as-is in append-pod-step-monitoring.py; remove sanitize_task_name (reviewer: task name cannot be dangerous).
- Use singular "Per task, per step" in cluster_read_config.yaml macro comment to align with "step" on the line.


Assisted-by: Cursor-AI@cursor.com
Made-with: Cursor
