### PR TITLE
fix: address pr52 review konflux 12064 12638

### DIFF
--- a/tests/load-tests/ci-scripts/config/README.md
+++ b/tests/load-tests/ci-scripts/config/README.md
@@ -29,14 +29,15 @@ Task/step memory and CPU labels
 -------------------------------
 
 Per-step metrics are under ``measurements.steps`` with key ``"<task_name>/<step_name>"``
-(e.g. ``$.measurements.steps["build/buildah-oci-ta/build"].memory.mean``).
+(e.g. ``$.measurements.steps."build/buildah-oci-ta/build".memory.mean``).
 Per-task (whole task) metrics are under ``measurements.tasks`` with key ``"<task_name>"``
-(e.g. ``$.measurements.tasks["build/buildah-oci-ta"].memory.mean``).
+(e.g. ``$.measurements.tasks."build/buildah-oci-ta".memory.mean`` or ``$.measurements.tasks."test/test-output".cpu.mean``).
 ``task_name`` in get-pod-step-names.json is ``<pipeline-type>/<pipelineTask>`` (e.g. ``build/build-container``),
 using ``tekton.dev/pipelineTask`` so keys are stable across runs.
 
 Label name = JSONPath with every non-alphanumeric character replaced by ``_``
-(e.g. ``__measurements_steps_build_buildah_oci_ta_build_memory_mean``).
+(consecutive replacements become multiple underscores, e.g.
+``__measurements_steps__build_buildah_oci_ta_build__memory_mean``).
 
 To regenerate labels (no extra scripts needed), use only the **latest run** per probe
 (one ``get-pod-step-names.json`` per ``ARTIFACTS/StoneSoupLoadTestProbe_*/``). Then:
@@ -78,4 +79,4 @@ Local verification
 
 - Validate schema and test JSON: ``jq empty horreum-schema.json horreum-test-ci.json``
 - List task/step labels: ``jq -r '.labels[] | select(.extractors[0].jsonpath | test("measurements\\.(steps|tasks)")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
-- Check a path in load-test.json: ``jq '.measurements.steps["build/buildah-oci-ta/build"].memory.mean' load-test.json``
+- Check a path in load-test.json: ``jq '.measurements.steps."build/buildah-oci-ta/build".memory.mean' load-test.json``

--- a/tests/load-tests/ci-scripts/config/README.md
+++ b/tests/load-tests/ci-scripts/config/README.md
@@ -25,36 +25,57 @@ To add a label given it's JSONPath expression:
     label_add="$( echo "$jsonpath_add" | sed 's/[^a-zA-Z0-9]/_/g' )"
     jq '.labels += [{"access": "PUBLIC", "owner": "hybrid-cloud-experience-perfscale-team", "name": "'"$label_add"'", "extractors": [{"name": "'"$label_add"'", "jsonpath": "'"$( echo "$jsonpath_add" | sed 's/"/\\\"/g' )"'", "isarray": false}], "_function": "", "filtering": false, "metrics": true, "schemaId": 169}]' ci-scripts/config/horreum-schema.json > tmp-$$.json && mv tmp-$$.json ci-scripts/config/horreum-schema.json
 
-Task/step memory and CPU labels (stable keys)
----------------------------------------------
+Task/step memory and CPU labels
+-------------------------------
 
-Per-task, per-step memory and CPU are stored under root ``measurements`` with
-run-specific keys ``tasks[<taskname>]`` (e.g. ``tasks[ocpp01cs-app-xaean-...-build-container]``).
-Task names change every run, so Horreum cannot use a fixed JSONPath on those keys.
+Per-step metrics are under ``measurements.steps`` with key ``"<task_name>/<step_name>"``
+(e.g. ``$.measurements.steps["build/buildah-oci-ta/build"].memory.mean``).
+Per-task (whole task) metrics are under ``measurements.tasks`` with key ``"<task_name>"``
+(e.g. ``$.measurements.tasks["build/buildah-oci-ta"].memory.mean``).
+``task_name`` in get-pod-step-names.json is ``<pipeline-type>/<pipelineTask>`` (e.g. ``build/build-container``),
+using ``tekton.dev/pipelineTask`` so keys are stable across runs.
 
-To fix this, the collect-results probe runs ``get-task-step-resources.py``, which
-injects ``measurements.stable_task_steps``: a stable view that maps logical task
-types (e.g. ``build-container``, ``collect-data``) and step names to the same
-metric dicts. Stable task type is taken from the TaskRun label
-``tekton.dev/pipelineTask`` when present (see get-pod-step-names.json), otherwise
-derived from the run-specific task name by suffix/TASK_ALIAS. Horreum labels use
-paths like ``$.measurements.stable_task_steps["build-container"]["build"].memory.mean``
-so the same path works every run.
+Label name = JSONPath with every non-alphanumeric character replaced by ``_``
+(e.g. ``__measurements_steps_build_buildah_oci_ta_build_memory_mean``).
 
-Label names in this schema must follow the same convention as other labels so they
-sync to PostgreSQL and work in Grafana: from the JSONPath, replace every
-non-alphanumeric character with ``_`` (e.g. ``__measurements_stable_task_steps_build_container_build_memory_mean``).
-Add more labels with that naming and jsonpath
-``$.measurements.stable_task_steps["<task-type>"]["<step-name>"].memory.mean`` or
-``.cpu.mean``. After changing the schema, re-import it in Horreum (see import guide above).
+To regenerate labels (no extra scripts needed), use only the **latest run** per probe
+(one ``get-pod-step-names.json`` per ``ARTIFACTS/StoneSoupLoadTestProbe_*/``). Then:
+
+**1. Collect path fragments** from each latest run's ``get-pod-step-names.json`` (four metric types).
+   Run these four jq expressions on each file; concatenate and sort -u:
+
+   - Step memory mean: ``jq -r '.pods[]? | .task_name as $task | .steps[]? | ".measurements.steps.\"" + $task + "/" + . + "\".memory.mean"' FILE``
+   - Step CPU mean: ``jq -r '.pods[]? | .task_name as $task | .steps[]? | ".measurements.steps.\"" + $task + "/" + . + "\".cpu.mean"' FILE``
+   - Task memory mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.tasks.\"" + . + "\".memory.mean"' FILE``
+   - Task CPU mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.tasks.\"" + . + "\".cpu.mean"' FILE``
+
+**2. Filter** out lines with an empty key or a key containing ``//`` (invalid, e.g. old ``"managed/"`` bug).
+
+**3. For each remaining path fragment** ``P``: full JSONPath = ``$`` + ``P``; label_name = ``echo "$jsonpath" | sed 's/[^a-zA-Z0-9]/_/g'``.
+
+**4. Update the schema:** delete the four old ``stable_task_steps`` labels (see "To delete a label" above; names contain ``stable_task_steps``). Then for each (jsonpath, label_name), use the "To add a label" recipe above (set ``jsonpath_add`` and ``label_add``, run the jq ``.labels += [...]``).
+
+Example to collect unique path fragments (latest run per probe only):
+
+```bash
+ARTIFACTS_DIR=/path/to/jenkins_artifacts/ARTIFACTS
+for d in "$ARTIFACTS_DIR"/StoneSoupLoadTestProbe_*/; do
+  f="$(ls -1d "$d"/run-* 2>/dev/null | sort -r | head -1)/get-pod-step-names.json"
+  [ -f "$f" ] || continue
+  jq -r '.pods[]? | .task_name as $t | .steps[]? | ".measurements.steps.\"" + $t + "/" + . + "\".memory.mean"' "$f"
+  jq -r '.pods[]? | .task_name as $t | .steps[]? | ".measurements.steps.\"" + $t + "/" + . + "\".cpu.mean"' "$f"
+  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.tasks.\"" + . + "\".memory.mean"' "$f"
+  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.tasks.\"" + . + "\".cpu.mean"' "$f"
+done | sort -u | grep -v '\.measurements\.\(steps\|tasks\)\.""' | grep -v '//'
+```
+
+Then for each line (path fragment ``P``), set ``jsonpath_add='$'+P`` and ``label_add="$(echo "$jsonpath_add" | sed 's/[^a-zA-Z0-9]/_/g')"`` and run the add-label jq from above (once per label).
+
+After changing the schema, re-import it in Horreum (see import guide above).
 
 Local verification
 ------------------
 
-You can validate config and jsonpaths locally (full Horreum extraction still
-requires uploading a run from Jenkins or re-importing the schema in Horreum):
-
-- Validate schema and test JSON are valid: ``jq empty horreum-schema.json horreum-test-ci.json``
-- List stable task/step labels: ``jq -r '.labels[] | select(.name | startswith("__measurements_stable_task_steps")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
-- After running get-task-step-resources.py on a run artifact dir, check stable path
-  extracts: ``jq '.measurements.stable_task_steps["build-container"]["build"].memory.mean' load-test.json``
+- Validate schema and test JSON: ``jq empty horreum-schema.json horreum-test-ci.json``
+- List task/step labels: ``jq -r '.labels[] | select(.extractors[0].jsonpath | test("measurements\\.(steps|tasks)")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
+- Check a path in load-test.json: ``jq '.measurements.steps["build/buildah-oci-ta/build"].memory.mean' load-test.json``

--- a/tests/load-tests/ci-scripts/config/README.md
+++ b/tests/load-tests/ci-scripts/config/README.md
@@ -35,12 +35,18 @@ Task names change every run, so Horreum cannot use a fixed JSONPath on those key
 To fix this, the collect-results probe runs ``get-task-step-resources.py``, which
 injects ``measurements.stable_task_steps``: a stable view that maps logical task
 types (e.g. ``build-container``, ``collect-data``) and step names to the same
-metric dicts. Task type is derived from the run-specific task name by suffix
-(e.g. ``*-build-container`` → ``build-container``). Horreum labels use paths like
-``$.measurements.stable_task_steps["build-container"]["build"].memory.mean`` so
-the same path works every run. Add more labels with
+metric dicts. Stable task type is taken from the TaskRun label
+``tekton.dev/pipelineTask`` when present (see get-pod-step-names.json), otherwise
+derived from the run-specific task name by suffix/TASK_ALIAS. Horreum labels use
+paths like ``$.measurements.stable_task_steps["build-container"]["build"].memory.mean``
+so the same path works every run.
+
+Label names in this schema must follow the same convention as other labels so they
+sync to PostgreSQL and work in Grafana: from the JSONPath, replace every
+non-alphanumeric character with ``_`` (e.g. ``__measurements_stable_task_steps_build_container_build_memory_mean``).
+Add more labels with that naming and jsonpath
 ``$.measurements.stable_task_steps["<task-type>"]["<step-name>"].memory.mean`` or
-``.cpu.mean``. After changing the schema, re-import it in Horreum.
+``.cpu.mean``. After changing the schema, re-import it in Horreum (see import guide above).
 
 Local verification
 ------------------
@@ -49,6 +55,6 @@ You can validate config and jsonpaths locally (full Horreum extraction still
 requires uploading a run from Jenkins or re-importing the schema in Horreum):
 
 - Validate schema and test JSON are valid: ``jq empty horreum-schema.json horreum-test-ci.json``
-- List stable task/step labels: ``jq -r '.labels[] | select(.name | startswith(".measurements.stable_task_steps")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
+- List stable task/step labels: ``jq -r '.labels[] | select(.name | startswith("__measurements_stable_task_steps")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
 - After running get-task-step-resources.py on a run artifact dir, check stable path
   extracts: ``jq '.measurements.stable_task_steps["build-container"]["build"].memory.mean' load-test.json``

--- a/tests/load-tests/ci-scripts/config/README.md
+++ b/tests/load-tests/ci-scripts/config/README.md
@@ -30,8 +30,8 @@ Task/step memory and CPU labels
 
 Per-step metrics are under ``measurements.steps`` with key ``"<task_name>/<step_name>"``
 (e.g. ``$.measurements.steps."build/buildah-oci-ta/build".memory.mean``).
-Per-task (whole task) metrics are under ``measurements.tasks`` with key ``"<task_name>"``
-(e.g. ``$.measurements.tasks."build/buildah-oci-ta".memory.mean`` or ``$.measurements.tasks."test/test-output".cpu.mean``).
+Per-task (whole task) metrics are under ``measurements.taskruns`` with key ``"<task_name>"``
+(e.g. ``$.measurements.taskruns."build/buildah-oci-ta".memory.mean`` or ``$.measurements.taskruns."test/test-output".cpu.mean``).
 ``task_name`` in get-pod-step-names.json is ``<pipeline-type>/<pipelineTask>`` (e.g. ``build/build-container``),
 using ``tekton.dev/pipelineTask`` so keys are stable across runs.
 
@@ -47,8 +47,8 @@ To regenerate labels (no extra scripts needed), use only the **latest run** per 
 
    - Step memory mean: ``jq -r '.pods[]? | .task_name as $task | .steps[]? | ".measurements.steps.\"" + $task + "/" + . + "\".memory.mean"' FILE``
    - Step CPU mean: ``jq -r '.pods[]? | .task_name as $task | .steps[]? | ".measurements.steps.\"" + $task + "/" + . + "\".cpu.mean"' FILE``
-   - Task memory mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.tasks.\"" + . + "\".memory.mean"' FILE``
-   - Task CPU mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.tasks.\"" + . + "\".cpu.mean"' FILE``
+   - Task memory mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.taskruns.\"" + . + "\".memory.mean"' FILE``
+   - Task CPU mean: ``jq -r '.pods[]? | .task_name | select(length > 0) | ".measurements.taskruns.\"" + . + "\".cpu.mean"' FILE``
 
 **2. Filter** out lines with an empty key or a key containing ``//`` (invalid, e.g. old ``"managed/"`` bug).
 
@@ -65,9 +65,9 @@ for d in "$ARTIFACTS_DIR"/StoneSoupLoadTestProbe_*/; do
   [ -f "$f" ] || continue
   jq -r '.pods[]? | .task_name as $t | .steps[]? | ".measurements.steps.\"" + $t + "/" + . + "\".memory.mean"' "$f"
   jq -r '.pods[]? | .task_name as $t | .steps[]? | ".measurements.steps.\"" + $t + "/" + . + "\".cpu.mean"' "$f"
-  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.tasks.\"" + . + "\".memory.mean"' "$f"
-  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.tasks.\"" + . + "\".cpu.mean"' "$f"
-done | sort -u | grep -v '\.measurements\.\(steps\|tasks\)\.""' | grep -v '//'
+  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.taskruns.\"" + . + "\".memory.mean"' "$f"
+  jq -r '.pods[]? | .task_name | select(length>0) | ".measurements.taskruns.\"" + . + "\".cpu.mean"' "$f"
+done | sort -u | grep -v '\.measurements\.\(steps\|taskruns\)\.""' | grep -v '//'
 ```
 
 Then for each line (path fragment ``P``), set ``jsonpath_add='$'+P`` and ``label_add="$(echo "$jsonpath_add" | sed 's/[^a-zA-Z0-9]/_/g')"`` and run the add-label jq from above (once per label).
@@ -78,5 +78,5 @@ Local verification
 ------------------
 
 - Validate schema and test JSON: ``jq empty horreum-schema.json horreum-test-ci.json``
-- List task/step labels: ``jq -r '.labels[] | select(.extractors[0].jsonpath | test("measurements\\.(steps|tasks)")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
+- List task/step labels: ``jq -r '.labels[] | select(.extractors[0].jsonpath | test("measurements\\.(steps|taskruns)")) | [.name, .extractors[0].jsonpath] | @tsv' horreum-schema.json``
 - Check a path in load-test.json: ``jq '.measurements.steps."build/buildah-oci-ta/build".memory.mean' load-test.json``

--- a/tests/load-tests/ci-scripts/config/horreum-schema.json
+++ b/tests/load-tests/ci-scripts/config/horreum-schema.json
@@ -5121,11 +5121,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_stable_task_steps_build_container_build_memory_mean",
+      "name": "__measurements_steps__build_apply_tags_apply_additional_tags__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_stable_task_steps_build_container_build_memory_mean",
-          "jsonpath": "$.measurements.stable_task_steps[\"build-container\"][\"build\"].memory.mean",
+          "name": "__measurements_steps__build_apply_tags_apply_additional_tags__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/apply-tags/apply-additional-tags\".cpu.mean",
           "isarray": false
         }
       ],
@@ -5137,11 +5137,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_stable_task_steps_build_container_build_cpu_mean",
+      "name": "__measurements_steps__build_apply_tags_apply_additional_tags__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_stable_task_steps_build_container_build_cpu_mean",
-          "jsonpath": "$.measurements.stable_task_steps[\"build-container\"][\"build\"].cpu.mean",
+          "name": "__measurements_steps__build_apply_tags_apply_additional_tags__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/apply-tags/apply-additional-tags\".memory.mean",
           "isarray": false
         }
       ],
@@ -5153,11 +5153,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_memory_mean",
+      "name": "__measurements_steps__build_build_image_index_build__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_memory_mean",
-          "jsonpath": "$.measurements.stable_task_steps[\"collect-data\"][\"create-trusted-artifact\"].memory.mean",
+          "name": "__measurements_steps__build_build_image_index_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/build\".cpu.mean",
           "isarray": false
         }
       ],
@@ -5169,11 +5169,4331 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_cpu_mean",
+      "name": "__measurements_steps__build_build_image_index_build__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_cpu_mean",
-          "jsonpath": "$.measurements.stable_task_steps[\"collect-data\"][\"create-trusted-artifact\"].cpu.mean",
+          "name": "__measurements_steps__build_build_image_index_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_build_image_index_create_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_build_image_index_create_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/create-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_build_image_index_create_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_build_image_index_create_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/create-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_build_image_index_upload_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_build_image_index_upload_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/upload-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_build_image_index_upload_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_build_image_index_upload_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/build-image-index/upload-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_build__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/build\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_build__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_prepare_sboms__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_prepare_sboms__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/prepare-sboms\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_prepare_sboms__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_prepare_sboms__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/prepare-sboms\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_push__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_push__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/push\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_push__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_push__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/push\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_sbom_syft_generate__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_sbom_syft_generate__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/sbom-syft-generate\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_sbom_syft_generate__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_sbom_syft_generate__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/sbom-syft-generate\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_upload_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_upload_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/upload-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_upload_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_upload_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/upload-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_build__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/build\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_build__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_prepare_sboms__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_prepare_sboms__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/prepare-sboms\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_prepare_sboms__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_prepare_sboms__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/prepare-sboms\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_push__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_push__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/push\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_push__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_push__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/push\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_sbom_syft_generate__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_sbom_syft_generate__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/sbom-syft-generate\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_sbom_syft_generate__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_sbom_syft_generate__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/sbom-syft-generate\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_upload_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_upload_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/upload-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_upload_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_upload_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/upload-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_buildah_remote_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_buildah_remote_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/buildah-remote-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_mock_build__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_mock_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/mock-build\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_mock_build__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_mock_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/mock-build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact_mock_config__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact_mock_config__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/use-trusted-artifact-mock-config\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact_mock_config__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_calculate_deps_use_trusted_artifact_mock_config__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/calculate-deps/use-trusted-artifact-mock-config\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_check_noarch__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_check_noarch__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/check-noarch\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_check_noarch__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_check_noarch__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/check-noarch\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_aarch64__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_aarch64__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-aarch64\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_aarch64__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_aarch64__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-aarch64\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_ppc64le__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_ppc64le__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-ppc64le\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_ppc64le__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_ppc64le__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-ppc64le\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_s390x__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_s390x__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-s390x\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_s390x__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_s390x__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-s390x\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_x86_64__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_x86_64__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-x86-64\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_x86_64__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_check_noarch_use_trusted_artifact_x86_64__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/check-noarch/use-trusted-artifact-x86-64\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_conftest_vulnerabilities__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_conftest_vulnerabilities__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/conftest-vulnerabilities\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_conftest_vulnerabilities__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_conftest_vulnerabilities__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/conftest-vulnerabilities\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_get_image_manifests__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_get_image_manifests__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/get-image-manifests\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_get_image_manifests__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_get_image_manifests__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/get-image-manifests\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_get_vulnerabilities__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_get_vulnerabilities__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/get-vulnerabilities\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_get_vulnerabilities__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_get_vulnerabilities__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/get-vulnerabilities\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_oci_attach_report__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_oci_attach_report__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/oci-attach-report\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clair_scan_oci_attach_report__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clair_scan_oci_attach_report__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clair-scan/oci-attach-report\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clamav_scan_extract_and_scan_image__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clamav_scan_extract_and_scan_image__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clamav-scan/extract-and-scan-image\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clamav_scan_extract_and_scan_image__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clamav_scan_extract_and_scan_image__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clamav-scan/extract-and-scan-image\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clamav_scan_upload__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clamav_scan_upload__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/clamav-scan/upload\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_clamav_scan_upload__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_clamav_scan_upload__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/clamav-scan/upload\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_coverity_availability_check_coverity_availability_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_coverity_availability_check_coverity_availability_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/coverity-availability-check/coverity-availability-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_coverity_availability_check_coverity_availability_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_coverity_availability_check_coverity_availability_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/coverity-availability-check/coverity-availability-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_deprecated_image_check_check_images__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_deprecated_image_check_check_images__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/deprecated-image-check/check-images\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_deprecated_image_check_check_images__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_deprecated_image_check_check_images__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/deprecated-image-check/check-images\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/app-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/app-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_set_outcome__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_set_outcome__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/app-set-outcome\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_set_outcome__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_app_set_outcome__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/app-set-outcome\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_final_outcome__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_final_outcome__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/final-outcome\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_final_outcome__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_final_outcome__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/final-outcome\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_generate_container_auth__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_generate_container_auth__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/generate-container-auth\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_generate_container_auth__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_generate_container_auth__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/generate-container-auth\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_introspect__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_introspect__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/introspect\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_introspect__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_introspect__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/introspect\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_set_skip_for_bundles__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_set_skip_for_bundles__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/set-skip-for-bundles\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_set_skip_for_bundles__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_ecosystem_cert_preflight_checks_set_skip_for_bundles__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/ecosystem-cert-preflight-checks/set-skip-for-bundles\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_get_build_target_get_build_target__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_get_build_target_get_build_target__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/get-build-target/get-build-target\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_get_build_target_get_build_target__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_get_build_target_get_build_target__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/get-build-target/get-build-target\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_clone__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_clone__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/clone\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_clone__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_clone__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/clone\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_symlink_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_symlink_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/symlink-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_git_clone_oci_ta_symlink_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_git_clone_oci_ta_symlink_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/git-clone-oci-ta/symlink-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_explode_srpm__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_explode_srpm__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/explode-srpm\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_explode_srpm__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_explode_srpm__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/explode-srpm\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_gather_rpms__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_gather_rpms__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/gather-rpms\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_gather_rpms__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_gather_rpms__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/gather-rpms\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_merge_syft_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_merge_syft_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/merge-syft-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_merge_syft_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_merge_syft_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/merge-syft-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_push_to_pulp_select_auth__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_push_to_pulp_select_auth__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/push-to-pulp-select-auth\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_push_to_pulp_select_auth__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_push_to_pulp_select_auth__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/push-to-pulp-select-auth\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_push_to_quay_select_auth__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_push_to_quay_select_auth__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/push-to-quay-select-auth\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_push_to_quay_select_auth__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_push_to_quay_select_auth__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/push-to-quay-select-auth\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_report_sbom_url__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_report_sbom_url__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/report-sbom-url\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_report_sbom_url__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_report_sbom_url__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/report-sbom-url\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_run_syft__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_run_syft__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/run-syft\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_run_syft__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_run_syft__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/run-syft\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_show_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_show_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/show-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_show_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_show_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/show-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_upload_sbom_to_quay__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_upload_sbom_to_quay__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/upload-sbom-to-quay\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_upload_sbom_to_quay__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_upload_sbom_to_quay__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/upload-sbom-to-quay\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_aarch64__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_aarch64__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-aarch64\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_aarch64__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_aarch64__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-aarch64\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_ppc64le__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_ppc64le__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-ppc64le\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_ppc64le__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_ppc64le__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-ppc64le\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_s390x__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_s390x__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-s390x\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_s390x__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_s390x__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-s390x\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_x86_64__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_x86_64__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-x86-64\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_x86_64__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_import_to_quay_use_trusted_artifact_x86_64__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/import-to-quay/use-trusted-artifact-x86-64\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_init_init__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_init_init__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/init/init\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_init_init__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_init_init__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/init/init\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_prefetch_dependencies__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_prefetch_dependencies__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/prefetch-dependencies\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_prefetch_dependencies__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_prefetch_dependencies__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/prefetch-dependencies\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_skip_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_skip_ta__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/skip-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_skip_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_skip_ta__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/skip-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prefetch_dependencies_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prefetch-dependencies-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_create_trusted_artifact_mock_config__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_create_trusted_artifact_mock_config__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/create-trusted-artifact-mock-config\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_create_trusted_artifact_mock_config__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_create_trusted_artifact_mock_config__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/create-trusted-artifact-mock-config\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_prepare_mock_config_template__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_prepare_mock_config_template__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/prepare-mock-config-template\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_prepare_mock_config_template__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_prepare_mock_config_template__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/prepare-mock-config-template\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_prepare_mock_config_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_prepare_mock_config_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/prepare-mock-config/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_download__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_download__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/download\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_download__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_download__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/download\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_select_mpc_machines_or_skip__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_select_mpc_machines_or_skip__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/select-mpc-machines-or-skip\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_select_mpc_machines_or_skip__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_select_mpc_machines_or_skip__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/select-mpc-machines-or-skip\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_process_sources_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_process_sources_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/process-sources/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_push_dockerfile_oci_ta_push__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_push_dockerfile_oci_ta_push__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/push-dockerfile-oci-ta/push\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_push_dockerfile_oci_ta_push__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_push_dockerfile_oci_ta_push__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/push-dockerfile-oci-ta/push\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_push_dockerfile_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_push_dockerfile_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/push-dockerfile-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_push_dockerfile_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_push_dockerfile_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/push-dockerfile-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_mock_build__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_mock_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/mock-build\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_mock_build__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_mock_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/mock-build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_mock_config__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_mock_config__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-mock-config\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_mock_config__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_mock_config__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-mock-config\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_results__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_results__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-results\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_results__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_results__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-results\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_source__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_source__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-source\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_source__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpmbuild_use_trusted_artifact_source__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpmbuild/use-trusted-artifact-source\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpms_signature_scan_output_results__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpms_signature_scan_output_results__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpms-signature-scan/output-results\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpms_signature_scan_output_results__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpms_signature_scan_output_results__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpms-signature-scan/output-results\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpms_signature_scan_rpms_signature_scan__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpms_signature_scan_rpms_signature_scan__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpms-signature-scan/rpms-signature-scan\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_rpms_signature_scan_rpms_signature_scan__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_rpms_signature_scan_rpms_signature_scan__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/rpms-signature-scan/rpms-signature-scan\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_sast_shell_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_sast_shell_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/sast-shell-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_sast_shell_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_sast_shell_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/sast-shell-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_upload__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_upload__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/upload\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_upload__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_upload__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/upload\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_shell_check_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_shell_check_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-shell-check-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_sast_snyk_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_sast_snyk_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/sast-snyk-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_sast_snyk_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_sast_snyk_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/sast-snyk-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_upload__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_upload__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/upload\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_upload__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_upload__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/upload\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_snyk_check_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_snyk_check_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-snyk-check-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_sast_unicode_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_sast_unicode_check__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/sast-unicode-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_sast_unicode_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_sast_unicode_check__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/sast-unicode-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_upload__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_upload__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/upload\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_upload__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_upload__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/upload\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_sast_unicode_check_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_sast_unicode_check_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/sast-unicode-check-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_show_sbom_show_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_show_sbom_show_sbom__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/show-sbom/show-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_show_sbom_show_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_show_sbom_show_sbom__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/show-sbom/show-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_build__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_build__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/build\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_build__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_build__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/build\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_get_base_images__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_get_base_images__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/get-base-images\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_get_base_images__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_get_base_images__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/get-base-images\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_source_build_oci_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_source_build_oci_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/source-build-oci-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_summary_appstudio_summary__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_summary_appstudio_summary__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"build/summary/appstudio-summary\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__build_summary_appstudio_summary__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__build_summary_appstudio_summary__memory_mean",
+          "jsonpath": "$.measurements.steps.\"build/summary/appstudio-summary\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_check_data_key_sources__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_check_data_key_sources__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/check-data-key-sources\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_check_data_key_sources__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_check_data_key_sources__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/check-data-key-sources\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_collect_data__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_collect_data__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/collect-data\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_collect_data__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_collect_data__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/collect-data\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_create_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_create_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/create-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_collect_data_create_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_collect_data_create_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/collect-data/create-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_assert__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_assert__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/assert\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_assert__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_assert__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/assert\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_info__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_info__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/info\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_info__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_info__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/info\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_initialize_tuf__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_initialize_tuf__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/initialize-tuf\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_initialize_tuf__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_initialize_tuf__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/initialize-tuf\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_reduce__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_reduce__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/reduce\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_reduce__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_reduce__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/reduce\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_report_json__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_report_json__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/report-json\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_report_json__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_report_json__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/report-json\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_show_config__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_show_config__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/show-config\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_show_config__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_show_config__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/show-config\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_summary__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_summary__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/summary\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_summary__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_summary__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/summary\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_use_trusted_artifact__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_use_trusted_artifact__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/use-trusted-artifact\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_use_trusted_artifact__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_use_trusted_artifact__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/use-trusted-artifact\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_validate__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_validate__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/validate\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_validate__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_validate__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/validate\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_version__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_version__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/version\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__managed_verify_conforma_konflux_ta_version__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__managed_verify_conforma_konflux_ta_version__memory_mean",
+          "jsonpath": "$.measurements.steps.\"managed/verify-conforma-konflux-ta/version\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__test_test_output_unnamed_0__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__test_test_output_unnamed_0__cpu_mean",
+          "jsonpath": "$.measurements.steps.\"test/test-output/unnamed-0\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_steps__test_test_output_unnamed_0__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_steps__test_test_output_unnamed_0__memory_mean",
+          "jsonpath": "$.measurements.steps.\"test/test-output/unnamed-0\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build___cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build___cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build___memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build___memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_apply_tags__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_apply_tags__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/apply-tags\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_apply_tags__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_apply_tags__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/apply-tags\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_build_image_index__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_build_image_index__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/build-image-index\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_build_image_index__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_build_image_index__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/build-image-index\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_buildah_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_buildah_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/buildah-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_buildah_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_buildah_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/buildah-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_buildah_remote_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_buildah_remote_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/buildah-remote-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_buildah_remote_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_buildah_remote_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/buildah-remote-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_calculate_deps__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_calculate_deps__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/calculate-deps\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_calculate_deps__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_calculate_deps__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/calculate-deps\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_check_noarch__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_check_noarch__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/check-noarch\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_check_noarch__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_check_noarch__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/check-noarch\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_clair_scan__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_clair_scan__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/clair-scan\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_clair_scan__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_clair_scan__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/clair-scan\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_clamav_scan__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_clamav_scan__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/clamav-scan\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_clamav_scan__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_clamav_scan__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/clamav-scan\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_coverity_availability_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_coverity_availability_check__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/coverity-availability-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_coverity_availability_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_coverity_availability_check__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/coverity-availability-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_deprecated_image_check__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_deprecated_image_check__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/deprecated-image-check\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_deprecated_image_check__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_deprecated_image_check__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/deprecated-image-check\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/ecosystem-cert-preflight-checks\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/ecosystem-cert-preflight-checks\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_get_build_target__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_get_build_target__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/get-build-target\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_get_build_target__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_get_build_target__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/get-build-target\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_git_clone_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_git_clone_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/git-clone-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_git_clone_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_git_clone_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/git-clone-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_import_to_quay__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_import_to_quay__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/import-to-quay\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_import_to_quay__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_import_to_quay__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/import-to-quay\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_init__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_init__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/init\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_init__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_init__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/init\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/prefetch-dependencies-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/prefetch-dependencies-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_prepare_mock_config__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_prepare_mock_config__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/prepare-mock-config\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_prepare_mock_config__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_prepare_mock_config__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/prepare-mock-config\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_process_sources__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_process_sources__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/process-sources\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_process_sources__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_process_sources__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/process-sources\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_push_dockerfile_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_push_dockerfile_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/push-dockerfile-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_push_dockerfile_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_push_dockerfile_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/push-dockerfile-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_rpmbuild__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_rpmbuild__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/rpmbuild\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_rpmbuild__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_rpmbuild__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/rpmbuild\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_rpms_signature_scan__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_rpms_signature_scan__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/rpms-signature-scan\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_rpms_signature_scan__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_rpms_signature_scan__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/rpms-signature-scan\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_shell_check_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_shell_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-shell-check-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_shell_check_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_shell_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-shell-check-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-snyk-check-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-snyk-check-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-unicode-check-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/sast-unicode-check-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_show_sbom__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_show_sbom__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/show-sbom\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_show_sbom__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_show_sbom__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/show-sbom\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_source_build_oci_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_source_build_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/source-build-oci-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_source_build_oci_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_source_build_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/source-build-oci-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_summary__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_summary__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"build/summary\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__build_summary__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__build_summary__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"build/summary\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed___cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed___cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed___memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed___memory_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed_collect_data__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed_collect_data__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/collect-data\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed_collect_data__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed_collect_data__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/collect-data\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/verify-conforma-konflux-ta\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"managed/verify-conforma-konflux-ta\".memory.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__test_test_output__cpu_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__test_test_output__cpu_mean",
+          "jsonpath": "$.measurements.tasks.\"test/test-output\".cpu.mean",
+          "isarray": false
+        }
+      ],
+      "_function": "",
+      "filtering": false,
+      "metrics": true,
+      "schemaId": 169
+    },
+    {
+      "access": "PUBLIC",
+      "owner": "hybrid-cloud-experience-perfscale-team",
+      "name": "__measurements_tasks__test_test_output__memory_mean",
+      "extractors": [
+        {
+          "name": "__measurements_tasks__test_test_output__memory_mean",
+          "jsonpath": "$.measurements.tasks.\"test/test-output\".memory.mean",
           "isarray": false
         }
       ],

--- a/tests/load-tests/ci-scripts/config/horreum-schema.json
+++ b/tests/load-tests/ci-scripts/config/horreum-schema.json
@@ -5121,10 +5121,10 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": ".measurements.stable_task_steps.build_container.build.memory.mean",
+      "name": "__measurements_stable_task_steps_build_container_build_memory_mean",
       "extractors": [
         {
-          "name": ".measurements.stable_task_steps.build_container.build.memory.mean",
+          "name": "__measurements_stable_task_steps_build_container_build_memory_mean",
           "jsonpath": "$.measurements.stable_task_steps[\"build-container\"][\"build\"].memory.mean",
           "isarray": false
         }
@@ -5137,10 +5137,10 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": ".measurements.stable_task_steps.build_container.build.cpu.mean",
+      "name": "__measurements_stable_task_steps_build_container_build_cpu_mean",
       "extractors": [
         {
-          "name": ".measurements.stable_task_steps.build_container.build.cpu.mean",
+          "name": "__measurements_stable_task_steps_build_container_build_cpu_mean",
           "jsonpath": "$.measurements.stable_task_steps[\"build-container\"][\"build\"].cpu.mean",
           "isarray": false
         }
@@ -5153,10 +5153,10 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": ".measurements.stable_task_steps.collect_data.create_trusted_artifact.memory.mean",
+      "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_memory_mean",
       "extractors": [
         {
-          "name": ".measurements.stable_task_steps.collect_data.create_trusted_artifact.memory.mean",
+          "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_memory_mean",
           "jsonpath": "$.measurements.stable_task_steps[\"collect-data\"][\"create-trusted-artifact\"].memory.mean",
           "isarray": false
         }
@@ -5169,10 +5169,10 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": ".measurements.stable_task_steps.collect_data.create_trusted_artifact.cpu.mean",
+      "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_cpu_mean",
       "extractors": [
         {
-          "name": ".measurements.stable_task_steps.collect_data.create_trusted_artifact.cpu.mean",
+          "name": "__measurements_stable_task_steps_collect_data_create_trusted_artifact_cpu_mean",
           "jsonpath": "$.measurements.stable_task_steps[\"collect-data\"][\"create-trusted-artifact\"].cpu.mean",
           "isarray": false
         }

--- a/tests/load-tests/ci-scripts/config/horreum-schema.json
+++ b/tests/load-tests/ci-scripts/config/horreum-schema.json
@@ -8481,11 +8481,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build___cpu_mean",
+      "name": "__measurements_taskruns__build_apply_tags__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build___cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/\".cpu.mean",
+          "name": "__measurements_taskruns__build_apply_tags__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/apply-tags\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8497,11 +8497,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build___memory_mean",
+      "name": "__measurements_taskruns__build_apply_tags__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build___memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/\".memory.mean",
+          "name": "__measurements_taskruns__build_apply_tags__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/apply-tags\".memory.mean",
           "isarray": false
         }
       ],
@@ -8513,11 +8513,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_apply_tags__cpu_mean",
+      "name": "__measurements_taskruns__build_build_image_index__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_apply_tags__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/apply-tags\".cpu.mean",
+          "name": "__measurements_taskruns__build_build_image_index__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/build-image-index\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8529,11 +8529,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_apply_tags__memory_mean",
+      "name": "__measurements_taskruns__build_build_image_index__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_apply_tags__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/apply-tags\".memory.mean",
+          "name": "__measurements_taskruns__build_build_image_index__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/build-image-index\".memory.mean",
           "isarray": false
         }
       ],
@@ -8545,11 +8545,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_build_image_index__cpu_mean",
+      "name": "__measurements_taskruns__build_buildah_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_build_image_index__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/build-image-index\".cpu.mean",
+          "name": "__measurements_taskruns__build_buildah_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/buildah-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8561,11 +8561,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_build_image_index__memory_mean",
+      "name": "__measurements_taskruns__build_buildah_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_build_image_index__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/build-image-index\".memory.mean",
+          "name": "__measurements_taskruns__build_buildah_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/buildah-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -8577,11 +8577,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_buildah_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_buildah_remote_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_buildah_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/buildah-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_buildah_remote_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/buildah-remote-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8593,11 +8593,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_buildah_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_buildah_remote_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_buildah_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/buildah-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_buildah_remote_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/buildah-remote-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -8609,11 +8609,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_buildah_remote_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_calculate_deps__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_buildah_remote_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/buildah-remote-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_calculate_deps__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/calculate-deps\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8625,11 +8625,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_buildah_remote_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_calculate_deps__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_buildah_remote_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/buildah-remote-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_calculate_deps__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/calculate-deps\".memory.mean",
           "isarray": false
         }
       ],
@@ -8641,11 +8641,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_calculate_deps__cpu_mean",
+      "name": "__measurements_taskruns__build_check_noarch__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_calculate_deps__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/calculate-deps\".cpu.mean",
+          "name": "__measurements_taskruns__build_check_noarch__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/check-noarch\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8657,11 +8657,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_calculate_deps__memory_mean",
+      "name": "__measurements_taskruns__build_check_noarch__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_calculate_deps__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/calculate-deps\".memory.mean",
+          "name": "__measurements_taskruns__build_check_noarch__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/check-noarch\".memory.mean",
           "isarray": false
         }
       ],
@@ -8673,11 +8673,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_check_noarch__cpu_mean",
+      "name": "__measurements_taskruns__build_clair_scan__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_check_noarch__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/check-noarch\".cpu.mean",
+          "name": "__measurements_taskruns__build_clair_scan__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/clair-scan\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8689,11 +8689,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_check_noarch__memory_mean",
+      "name": "__measurements_taskruns__build_clair_scan__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_check_noarch__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/check-noarch\".memory.mean",
+          "name": "__measurements_taskruns__build_clair_scan__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/clair-scan\".memory.mean",
           "isarray": false
         }
       ],
@@ -8705,11 +8705,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_clair_scan__cpu_mean",
+      "name": "__measurements_taskruns__build_clamav_scan__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_clair_scan__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/clair-scan\".cpu.mean",
+          "name": "__measurements_taskruns__build_clamav_scan__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/clamav-scan\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8721,11 +8721,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_clair_scan__memory_mean",
+      "name": "__measurements_taskruns__build_clamav_scan__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_clair_scan__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/clair-scan\".memory.mean",
+          "name": "__measurements_taskruns__build_clamav_scan__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/clamav-scan\".memory.mean",
           "isarray": false
         }
       ],
@@ -8737,11 +8737,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_clamav_scan__cpu_mean",
+      "name": "__measurements_taskruns__build_coverity_availability_check__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_clamav_scan__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/clamav-scan\".cpu.mean",
+          "name": "__measurements_taskruns__build_coverity_availability_check__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/coverity-availability-check\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8753,11 +8753,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_clamav_scan__memory_mean",
+      "name": "__measurements_taskruns__build_coverity_availability_check__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_clamav_scan__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/clamav-scan\".memory.mean",
+          "name": "__measurements_taskruns__build_coverity_availability_check__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/coverity-availability-check\".memory.mean",
           "isarray": false
         }
       ],
@@ -8769,11 +8769,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_coverity_availability_check__cpu_mean",
+      "name": "__measurements_taskruns__build_deprecated_image_check__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_coverity_availability_check__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/coverity-availability-check\".cpu.mean",
+          "name": "__measurements_taskruns__build_deprecated_image_check__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/deprecated-image-check\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8785,11 +8785,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_coverity_availability_check__memory_mean",
+      "name": "__measurements_taskruns__build_deprecated_image_check__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_coverity_availability_check__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/coverity-availability-check\".memory.mean",
+          "name": "__measurements_taskruns__build_deprecated_image_check__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/deprecated-image-check\".memory.mean",
           "isarray": false
         }
       ],
@@ -8801,11 +8801,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_deprecated_image_check__cpu_mean",
+      "name": "__measurements_taskruns__build_ecosystem_cert_preflight_checks__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_deprecated_image_check__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/deprecated-image-check\".cpu.mean",
+          "name": "__measurements_taskruns__build_ecosystem_cert_preflight_checks__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/ecosystem-cert-preflight-checks\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8817,11 +8817,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_deprecated_image_check__memory_mean",
+      "name": "__measurements_taskruns__build_ecosystem_cert_preflight_checks__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_deprecated_image_check__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/deprecated-image-check\".memory.mean",
+          "name": "__measurements_taskruns__build_ecosystem_cert_preflight_checks__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/ecosystem-cert-preflight-checks\".memory.mean",
           "isarray": false
         }
       ],
@@ -8833,11 +8833,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__cpu_mean",
+      "name": "__measurements_taskruns__build_get_build_target__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/ecosystem-cert-preflight-checks\".cpu.mean",
+          "name": "__measurements_taskruns__build_get_build_target__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/get-build-target\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8849,11 +8849,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__memory_mean",
+      "name": "__measurements_taskruns__build_get_build_target__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_ecosystem_cert_preflight_checks__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/ecosystem-cert-preflight-checks\".memory.mean",
+          "name": "__measurements_taskruns__build_get_build_target__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/get-build-target\".memory.mean",
           "isarray": false
         }
       ],
@@ -8865,11 +8865,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_get_build_target__cpu_mean",
+      "name": "__measurements_taskruns__build_git_clone_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_get_build_target__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/get-build-target\".cpu.mean",
+          "name": "__measurements_taskruns__build_git_clone_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/git-clone-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8881,11 +8881,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_get_build_target__memory_mean",
+      "name": "__measurements_taskruns__build_git_clone_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_get_build_target__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/get-build-target\".memory.mean",
+          "name": "__measurements_taskruns__build_git_clone_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/git-clone-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -8897,11 +8897,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_git_clone_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_import_to_quay__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_git_clone_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/git-clone-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_import_to_quay__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/import-to-quay\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8913,11 +8913,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_git_clone_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_import_to_quay__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_git_clone_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/git-clone-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_import_to_quay__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/import-to-quay\".memory.mean",
           "isarray": false
         }
       ],
@@ -8929,11 +8929,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_import_to_quay__cpu_mean",
+      "name": "__measurements_taskruns__build_init__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_import_to_quay__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/import-to-quay\".cpu.mean",
+          "name": "__measurements_taskruns__build_init__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/init\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8945,11 +8945,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_import_to_quay__memory_mean",
+      "name": "__measurements_taskruns__build_init__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_import_to_quay__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/import-to-quay\".memory.mean",
+          "name": "__measurements_taskruns__build_init__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/init\".memory.mean",
           "isarray": false
         }
       ],
@@ -8961,11 +8961,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_init__cpu_mean",
+      "name": "__measurements_taskruns__build_prefetch_dependencies_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_init__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/init\".cpu.mean",
+          "name": "__measurements_taskruns__build_prefetch_dependencies_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/prefetch-dependencies-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -8977,11 +8977,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_init__memory_mean",
+      "name": "__measurements_taskruns__build_prefetch_dependencies_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_init__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/init\".memory.mean",
+          "name": "__measurements_taskruns__build_prefetch_dependencies_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/prefetch-dependencies-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -8993,11 +8993,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_prepare_mock_config__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/prefetch-dependencies-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_prepare_mock_config__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/prepare-mock-config\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9009,11 +9009,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_prepare_mock_config__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_prefetch_dependencies_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/prefetch-dependencies-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_prepare_mock_config__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/prepare-mock-config\".memory.mean",
           "isarray": false
         }
       ],
@@ -9025,11 +9025,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_prepare_mock_config__cpu_mean",
+      "name": "__measurements_taskruns__build_process_sources__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_prepare_mock_config__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/prepare-mock-config\".cpu.mean",
+          "name": "__measurements_taskruns__build_process_sources__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/process-sources\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9041,11 +9041,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_prepare_mock_config__memory_mean",
+      "name": "__measurements_taskruns__build_process_sources__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_prepare_mock_config__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/prepare-mock-config\".memory.mean",
+          "name": "__measurements_taskruns__build_process_sources__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/process-sources\".memory.mean",
           "isarray": false
         }
       ],
@@ -9057,11 +9057,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_process_sources__cpu_mean",
+      "name": "__measurements_taskruns__build_push_dockerfile_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_process_sources__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/process-sources\".cpu.mean",
+          "name": "__measurements_taskruns__build_push_dockerfile_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/push-dockerfile-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9073,11 +9073,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_process_sources__memory_mean",
+      "name": "__measurements_taskruns__build_push_dockerfile_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_process_sources__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/process-sources\".memory.mean",
+          "name": "__measurements_taskruns__build_push_dockerfile_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/push-dockerfile-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9089,11 +9089,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_push_dockerfile_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_rpmbuild__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_push_dockerfile_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/push-dockerfile-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_rpmbuild__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/rpmbuild\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9105,11 +9105,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_push_dockerfile_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_rpmbuild__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_push_dockerfile_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/push-dockerfile-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_rpmbuild__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/rpmbuild\".memory.mean",
           "isarray": false
         }
       ],
@@ -9121,11 +9121,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_rpmbuild__cpu_mean",
+      "name": "__measurements_taskruns__build_rpms_signature_scan__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_rpmbuild__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/rpmbuild\".cpu.mean",
+          "name": "__measurements_taskruns__build_rpms_signature_scan__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/rpms-signature-scan\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9137,11 +9137,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_rpmbuild__memory_mean",
+      "name": "__measurements_taskruns__build_rpms_signature_scan__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_rpmbuild__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/rpmbuild\".memory.mean",
+          "name": "__measurements_taskruns__build_rpms_signature_scan__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/rpms-signature-scan\".memory.mean",
           "isarray": false
         }
       ],
@@ -9153,11 +9153,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_rpms_signature_scan__cpu_mean",
+      "name": "__measurements_taskruns__build_sast_shell_check_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_rpms_signature_scan__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/rpms-signature-scan\".cpu.mean",
+          "name": "__measurements_taskruns__build_sast_shell_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-shell-check-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9169,11 +9169,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_rpms_signature_scan__memory_mean",
+      "name": "__measurements_taskruns__build_sast_shell_check_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_rpms_signature_scan__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/rpms-signature-scan\".memory.mean",
+          "name": "__measurements_taskruns__build_sast_shell_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-shell-check-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9185,11 +9185,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_shell_check_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_sast_snyk_check_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_shell_check_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-shell-check-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_sast_snyk_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-snyk-check-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9201,11 +9201,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_shell_check_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_sast_snyk_check_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_shell_check_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-shell-check-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_sast_snyk_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-snyk-check-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9217,11 +9217,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_sast_unicode_check_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-snyk-check-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_sast_unicode_check_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-unicode-check-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9233,11 +9233,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_sast_unicode_check_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_snyk_check_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-snyk-check-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_sast_unicode_check_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/sast-unicode-check-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9249,11 +9249,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_show_sbom__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-unicode-check-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_show_sbom__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/show-sbom\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9265,11 +9265,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_show_sbom__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_sast_unicode_check_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/sast-unicode-check-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_show_sbom__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/show-sbom\".memory.mean",
           "isarray": false
         }
       ],
@@ -9281,11 +9281,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_show_sbom__cpu_mean",
+      "name": "__measurements_taskruns__build_source_build_oci_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_show_sbom__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/show-sbom\".cpu.mean",
+          "name": "__measurements_taskruns__build_source_build_oci_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/source-build-oci-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9297,11 +9297,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_show_sbom__memory_mean",
+      "name": "__measurements_taskruns__build_source_build_oci_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_show_sbom__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/show-sbom\".memory.mean",
+          "name": "__measurements_taskruns__build_source_build_oci_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/source-build-oci-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9313,11 +9313,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_source_build_oci_ta__cpu_mean",
+      "name": "__measurements_taskruns__build_summary__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_source_build_oci_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/source-build-oci-ta\".cpu.mean",
+          "name": "__measurements_taskruns__build_summary__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/summary\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9329,11 +9329,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_source_build_oci_ta__memory_mean",
+      "name": "__measurements_taskruns__build_summary__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_source_build_oci_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/source-build-oci-ta\".memory.mean",
+          "name": "__measurements_taskruns__build_summary__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"build/summary\".memory.mean",
           "isarray": false
         }
       ],
@@ -9345,11 +9345,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_summary__cpu_mean",
+      "name": "__measurements_taskruns__managed_collect_data__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_summary__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"build/summary\".cpu.mean",
+          "name": "__measurements_taskruns__managed_collect_data__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"managed/collect-data\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9361,11 +9361,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__build_summary__memory_mean",
+      "name": "__measurements_taskruns__managed_collect_data__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__build_summary__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"build/summary\".memory.mean",
+          "name": "__measurements_taskruns__managed_collect_data__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"managed/collect-data\".memory.mean",
           "isarray": false
         }
       ],
@@ -9377,11 +9377,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed___cpu_mean",
+      "name": "__measurements_taskruns__managed_verify_conforma_konflux_ta__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__managed___cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/\".cpu.mean",
+          "name": "__measurements_taskruns__managed_verify_conforma_konflux_ta__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"managed/verify-conforma-konflux-ta\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9393,11 +9393,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed___memory_mean",
+      "name": "__measurements_taskruns__managed_verify_conforma_konflux_ta__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__managed___memory_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/\".memory.mean",
+          "name": "__measurements_taskruns__managed_verify_conforma_konflux_ta__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"managed/verify-conforma-konflux-ta\".memory.mean",
           "isarray": false
         }
       ],
@@ -9409,11 +9409,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed_collect_data__cpu_mean",
+      "name": "__measurements_taskruns__test_test_output__cpu_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__managed_collect_data__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/collect-data\".cpu.mean",
+          "name": "__measurements_taskruns__test_test_output__cpu_mean",
+          "jsonpath": "$.measurements.taskruns.\"test/test-output\".cpu.mean",
           "isarray": false
         }
       ],
@@ -9425,75 +9425,11 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed_collect_data__memory_mean",
+      "name": "__measurements_taskruns__test_test_output__memory_mean",
       "extractors": [
         {
-          "name": "__measurements_tasks__managed_collect_data__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/collect-data\".memory.mean",
-          "isarray": false
-        }
-      ],
-      "_function": "",
-      "filtering": false,
-      "metrics": true,
-      "schemaId": 169
-    },
-    {
-      "access": "PUBLIC",
-      "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__cpu_mean",
-      "extractors": [
-        {
-          "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/verify-conforma-konflux-ta\".cpu.mean",
-          "isarray": false
-        }
-      ],
-      "_function": "",
-      "filtering": false,
-      "metrics": true,
-      "schemaId": 169
-    },
-    {
-      "access": "PUBLIC",
-      "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__memory_mean",
-      "extractors": [
-        {
-          "name": "__measurements_tasks__managed_verify_conforma_konflux_ta__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"managed/verify-conforma-konflux-ta\".memory.mean",
-          "isarray": false
-        }
-      ],
-      "_function": "",
-      "filtering": false,
-      "metrics": true,
-      "schemaId": 169
-    },
-    {
-      "access": "PUBLIC",
-      "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__test_test_output__cpu_mean",
-      "extractors": [
-        {
-          "name": "__measurements_tasks__test_test_output__cpu_mean",
-          "jsonpath": "$.measurements.tasks.\"test/test-output\".cpu.mean",
-          "isarray": false
-        }
-      ],
-      "_function": "",
-      "filtering": false,
-      "metrics": true,
-      "schemaId": 169
-    },
-    {
-      "access": "PUBLIC",
-      "owner": "hybrid-cloud-experience-perfscale-team",
-      "name": "__measurements_tasks__test_test_output__memory_mean",
-      "extractors": [
-        {
-          "name": "__measurements_tasks__test_test_output__memory_mean",
-          "jsonpath": "$.measurements.tasks.\"test/test-output\".memory.mean",
+          "name": "__measurements_taskruns__test_test_output__memory_mean",
+          "jsonpath": "$.measurements.taskruns.\"test/test-output\".memory.mean",
           "isarray": false
         }
       ],

--- a/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
@@ -83,8 +83,7 @@ if [[ -d "$CD" ]]; then
     {
       namespace: .metadata.namespace,
       pod_id: .status.podName,
-      task_name: (.metadata.labels."pipelines.appstudio.openshift.io/type" + "/" + .metadata.labels."tekton.dev/task"),
-      pipeline_task: (.metadata.labels."tekton.dev/pipelineTask" // ""),
+      task_name: (.metadata.labels."pipelines.appstudio.openshift.io/type" + "/" + (.metadata.labels."tekton.dev/pipelineTask" // .metadata.labels."tekton.dev/task" // "unknown")),
       steps: [.status.steps[]?.name]
     } | select(.steps | length > 0)
   ' {} + 2>/dev/null | jq -s '
@@ -95,12 +94,11 @@ if [[ ! -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]]; then
   echo '{"pods":[]}' > "${ARTIFACT_DIR}/get-pod-step-names.json"
 fi
 
-echo "[$(date --utc -Ins)] Appending dynamic task and step monitoring to cluster_read_config.yaml_modified"
-cp ci-scripts/stage/cluster_read_config.yaml "${ARTIFACT_DIR}/cluster_read_config.yaml_modified"
-if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]]; then
+echo "[$(date --utc -Ins)] Appending dynamic monitor_task_step entries and saving as cluster_read_config.yaml_modified"
+if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]] && jq -e '.pods | length > 0' "${ARTIFACT_DIR}/get-pod-step-names.json" >/dev/null 2>&1; then
     ci-scripts/utility_scripts/append-pod-step-monitoring.py \
         --pod-step-json "${ARTIFACT_DIR}/get-pod-step-names.json" \
-        >>"${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
+        --output "${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
 else
     cp -f ci-scripts/stage/cluster_read_config.yaml "${ARTIFACT_DIR}/cluster_read_config.yaml_modified"
 fi

--- a/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
@@ -94,11 +94,12 @@ if [[ ! -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]]; then
   echo '{"pods":[]}' > "${ARTIFACT_DIR}/get-pod-step-names.json"
 fi
 
-echo "[$(date --utc -Ins)] Appending dynamic monitor_task_step entries and saving as cluster_read_config.yaml_modified"
-if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]] && jq -e '.pods | length > 0' "${ARTIFACT_DIR}/get-pod-step-names.json" >/dev/null 2>&1; then
+echo "[$(date --utc -Ins)] Appending dynamic task and step monitoring to cluster_read_config.yaml_modified"
+cp ci-scripts/stage/cluster_read_config.yaml "${ARTIFACT_DIR}/cluster_read_config.yaml_modified"
+if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]]; then
     ci-scripts/utility_scripts/append-pod-step-monitoring.py \
         --pod-step-json "${ARTIFACT_DIR}/get-pod-step-names.json" \
-        >"${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
+        >>"${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
 else
     cp -f ci-scripts/stage/cluster_read_config.yaml "${ARTIFACT_DIR}/cluster_read_config.yaml_modified"
 fi

--- a/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
@@ -84,6 +84,7 @@ if [[ -d "$CD" ]]; then
       namespace: .metadata.namespace,
       pod_id: .status.podName,
       task_name: (.metadata.labels."pipelines.appstudio.openshift.io/type" + "/" + .metadata.labels."tekton.dev/task"),
+      pipeline_task: (.metadata.labels."tekton.dev/pipelineTask" // ""),
       steps: [.status.steps[]?.name]
     } | select(.steps | length > 0)
   ' {} + 2>/dev/null | jq -s '

--- a/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results-probe.sh
@@ -83,7 +83,7 @@ if [[ -d "$CD" ]]; then
     {
       namespace: .metadata.namespace,
       pod_id: .status.podName,
-      task_name: (.metadata.labels."pipelines.appstudio.openshift.io/type" + "/" + (.metadata.labels."tekton.dev/pipelineTask" // .metadata.labels."tekton.dev/task" // "unknown")),
+      task_name: (.metadata.labels."pipelines.appstudio.openshift.io/type" + "/" + .metadata.labels."tekton.dev/pipelineTask"),
       steps: [.status.steps[]?.name]
     } | select(.steps | length > 0)
   ' {} + 2>/dev/null | jq -s '
@@ -98,7 +98,7 @@ echo "[$(date --utc -Ins)] Appending dynamic monitor_task_step entries and savin
 if [[ -s "${ARTIFACT_DIR}/get-pod-step-names.json" ]] && jq -e '.pods | length > 0' "${ARTIFACT_DIR}/get-pod-step-names.json" >/dev/null 2>&1; then
     ci-scripts/utility_scripts/append-pod-step-monitoring.py \
         --pod-step-json "${ARTIFACT_DIR}/get-pod-step-names.json" \
-        --output "${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
+        >"${ARTIFACT_DIR}/cluster_read_config.yaml_modified" || true
 else
     cp -f ci-scripts/stage/cluster_read_config.yaml "${ARTIFACT_DIR}/cluster_read_config.yaml_modified"
 fi

--- a/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
+++ b/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
@@ -1,58 +1,53 @@
 #!/usr/bin/env python3
 """
-Emit full cluster_read_config.yaml (base + dynamic lines) to stdout
-from get-pod-step-names.json. Base file is ci-scripts/stage/cluster_read_config.yaml.
+Generate monitor_task() and monitor_task_step() macro calls in Jinja2 for
+cluster_read_config.yaml from get-pod-step-names.json.
 """
 
 import argparse
 import json
-import os
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument(
-        "--pod-step-json", required=True, help="get-pod-step-names.json path"
+        "--pod-step-json",
+        required=True,
+        help="get-pod-step-names.json path",
     )
-    ap.add_argument("--step-default", type=int, default=15)
-    ap.add_argument("--pod-suffix-regex", default="", help="e.g. '' or '-[0-9a-f]+-.*'")
+    ap.add_argument(
+        "--step-default",
+        type=int,
+        default=15,
+    )
+    ap.add_argument(
+        "--pod-suffix-regex",
+        default="",
+        help="e.g. '' or '-[0-9a-f]+-.*'",
+    )
     args = ap.parse_args()
 
     with open(args.pod_step_json) as f:
         data = json.load(f)
 
-    input_yaml = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__), "..", "stage", "cluster_read_config.yaml"
-        )
+    print(
+        "\n# Dynamic task/step monitoring (from parsed collected-data; stored under task name)\n"
     )
 
-    lines = []
     for entry in data.get("pods", []):
         ns = entry["namespace"]
         pod_id = entry["pod_id"]
-        task_name = entry.get("task_name", pod_id)
+        task_name = entry["task_name"]
+
+        print(
+            f"{{{{ monitor_task('{ns}', '{pod_id}', '{task_name}', {args.step_default}, '{args.pod_suffix_regex}') }}}}"
+        )
+
         for step in entry["steps"]:
-            lines.append(
-                "{{ monitor_task_step('%s', '%s', '%s', '%s', %s, '%s') }}"
-                % (
-                    ns,
-                    pod_id,
-                    task_name,
-                    step,
-                    args.step_default,
-                    args.pod_suffix_regex,
-                )
+            print(
+                f"{{{{ monitor_task_step('{ns}', '{pod_id}', 'step-{step}', '{task_name}/{step}', {args.step_default}, '{args.pod_suffix_regex}') }}}}"
             )
 
-    with open(input_yaml) as f:
-        content = f.read()
-
-    suffix = "\n# Dynamic task/step monitoring (from parsed collected-data; stored under task name)\n"
-    suffix += "\n".join(lines)
-    suffix += "\n"
-
-    print(content + suffix, end="")
     return 0
 
 

--- a/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
+++ b/tests/load-tests/ci-scripts/utility_scripts/append-pod-step-monitoring.py
@@ -1,53 +1,58 @@
 #!/usr/bin/env python3
 """
-Generate monitor_task() and monitor_task_step() macro calls in Jinja2 for
-cluster_read_config.yaml from get-pod-step-names.json.
+Emit full cluster_read_config.yaml (base + dynamic lines) to stdout
+from get-pod-step-names.json. Base file is ci-scripts/stage/cluster_read_config.yaml.
 """
 
 import argparse
 import json
+import os
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument(
-        "--pod-step-json",
-        required=True,
-        help="get-pod-step-names.json path",
+        "--pod-step-json", required=True, help="get-pod-step-names.json path"
     )
-    ap.add_argument(
-        "--step-default",
-        type=int,
-        default=15,
-    )
-    ap.add_argument(
-        "--pod-suffix-regex",
-        default="",
-        help="e.g. '' or '-[0-9a-f]+-.*'",
-    )
+    ap.add_argument("--step-default", type=int, default=15)
+    ap.add_argument("--pod-suffix-regex", default="", help="e.g. '' or '-[0-9a-f]+-.*'")
     args = ap.parse_args()
 
     with open(args.pod_step_json) as f:
         data = json.load(f)
 
-    print(
-        "\n# Dynamic task/step monitoring from parsed collected-data; stored under task name)\n"
+    input_yaml = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__), "..", "stage", "cluster_read_config.yaml"
+        )
     )
 
+    lines = []
     for entry in data.get("pods", []):
         ns = entry["namespace"]
         pod_id = entry["pod_id"]
-        task_name = entry["task_name"]
-
-        print(
-            f"{{{{ monitor_task('{ns}', '{pod_id}', '{task_name}', {args.step_default}, '{args.pod_suffix_regex}') }}}}"
-        )
-
+        task_name = entry.get("task_name", pod_id)
         for step in entry["steps"]:
-            print(
-                f"{{{{ monitor_task_step('{ns}', '{pod_id}', 'step-{step}', '{task_name}/{step}', {args.step_default}, '{args.pod_suffix_regex}') }}}}"
+            lines.append(
+                "{{ monitor_task_step('%s', '%s', '%s', '%s', %s, '%s') }}"
+                % (
+                    ns,
+                    pod_id,
+                    task_name,
+                    step,
+                    args.step_default,
+                    args.pod_suffix_regex,
+                )
             )
 
+    with open(input_yaml) as f:
+        content = f.read()
+
+    suffix = "\n# Dynamic task/step monitoring (from parsed collected-data; stored under task name)\n"
+    suffix += "\n".join(lines)
+    suffix += "\n"
+
+    print(content + suffix, end="")
     return 0
 
 


### PR DESCRIPTION
# Address PR #52 review + KONFLUX-12064 / KONFLUX-12638 (e2e-tests)

## Why

- **KONFLUX-12064:** After PR #52 (perfscale Grafana panels), the new task/step memory and CPU labels were still not visible in Horreum (schema 169). Labels in the schema must use the same naming convention as other labels (jsonpath → replace non-alphanumeric with `_`, e.g. `__measurements_stable_task_steps_...`) so they sync to PostgreSQL and work in Grafana.
- **KONFLUX-12638 (reviewer):** We should prefer the TaskRun label `tekton.dev/pipelineTask` (e.g. `"build-container"`) as the stable key instead of deriving it from the task name via TASK_ALIAS/suffix. The label is already present on TaskRuns; using it avoids maintaining a separate mapping.

## What

- **horreum-schema.json:** Rename the four stable_task_steps label definitions from `.measurements.stable_task_steps....` to `__measurements_stable_task_steps_...` (same jsonpaths, names only). Ensures they match the convention used by existing duration labels and sync correctly when the schema is re-imported into Horreum.
- **collect-results-probe.sh:** When building `get-pod-step-names.json` from TaskRun JSON, add `pipeline_task` from `metadata.labels["tekton.dev/pipelineTask"]` (empty string if missing).
- **get-task-step-resources.py:** Build a `task_name → pipeline_task` map from `get-pod-step-names.json`. When building `stable_task_steps`, use `pipeline_task` when present; otherwise fall back to `stable_task_type()` (suffix + TASK_ALIAS). Add comment that TASK_ALIAS is fallback when the label is absent.
- **config/README.md:** Document that stable_task_steps labels must use the same naming convention; update the “list labels” jq example to the new prefix; note pipeline_task usage.

## How

- Label names were derived from the existing jsonpaths by replacing every non-alphanumeric character with `_` (per README).
- `build_pipeline_task_map()` reads pod entries and normalizes `task_name` the same way as in the monitoring config (`.` and `/` → `_`).
- `build_stable_task_steps_from_nested()` now accepts an optional `pipeline_task_map`; for each task, `stable = pipeline_task_map.get(task_name) or stable_task_type(task_name)`.

## Jira

- **KONFLUX-12064** – Labels in Horreum (schema 169): naming fix in this PR; schema re-import into Horreum is a separate step (see README import guide).
- **KONFLUX-12638** – Prefer pipelineTask over TASK_ALIAS; small refactor/doc.