### PR TITLE
chore(horreum): align horreum-schema.json with imported schema 169 (try01)

### DIFF
--- a/tests/load-tests/ci-scripts/config/horreum-schema.json
+++ b/tests/load-tests/ci-scripts/config/horreum-schema.json
@@ -6124,6 +6124,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15038,
       "name": "__results_durations_stats_taskruns__build_buildah_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -6140,6 +6141,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15039,
       "name": "__results_durations_stats_taskruns__build_buildah_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -6156,6 +6158,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15040,
       "name": "__results_durations_stats_taskruns__build_buildah_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -6172,6 +6175,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15041,
       "name": "__results_durations_stats_taskruns__build_buildah_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -6188,6 +6192,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15042,
       "name": "__results_durations_stats_taskruns__build_buildah_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -7224,6 +7229,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15044,
       "name": "__results_durations_stats_taskruns__build_prefetch_dependencies_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -7240,6 +7246,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15043,
       "name": "__results_durations_stats_taskruns__build_prefetch_dependencies_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -7256,6 +7263,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15045,
       "name": "__results_durations_stats_taskruns__build_prefetch_dependencies_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -7272,6 +7280,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15046,
       "name": "__results_durations_stats_taskruns__build_prefetch_dependencies_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -7288,6 +7297,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15047,
       "name": "__results_durations_stats_taskruns__build_prefetch_dependencies_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -7389,6 +7399,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15049,
       "name": "__results_durations_stats_taskruns__build_push_dockerfile_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -7405,6 +7416,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15048,
       "name": "__results_durations_stats_taskruns__build_push_dockerfile_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -7421,6 +7433,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15050,
       "name": "__results_durations_stats_taskruns__build_push_dockerfile_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -7437,6 +7450,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15051,
       "name": "__results_durations_stats_taskruns__build_push_dockerfile_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -7453,6 +7467,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15052,
       "name": "__results_durations_stats_taskruns__build_push_dockerfile_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -7724,6 +7739,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15054,
       "name": "__results_durations_stats_taskruns__build_sast_shell_check_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -7740,6 +7756,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15053,
       "name": "__results_durations_stats_taskruns__build_sast_shell_check_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -7756,6 +7773,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15055,
       "name": "__results_durations_stats_taskruns__build_sast_shell_check_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -7772,6 +7790,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15056,
       "name": "__results_durations_stats_taskruns__build_sast_shell_check_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -7788,6 +7807,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15057,
       "name": "__results_durations_stats_taskruns__build_sast_shell_check_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -7889,6 +7909,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15059,
       "name": "__results_durations_stats_taskruns__build_sast_snyk_check_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -7905,6 +7926,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15058,
       "name": "__results_durations_stats_taskruns__build_sast_snyk_check_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -7921,6 +7943,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15060,
       "name": "__results_durations_stats_taskruns__build_sast_snyk_check_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -7937,6 +7960,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15061,
       "name": "__results_durations_stats_taskruns__build_sast_snyk_check_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -7953,6 +7977,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15062,
       "name": "__results_durations_stats_taskruns__build_sast_snyk_check_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -8054,6 +8079,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15064,
       "name": "__results_durations_stats_taskruns__build_sast_unicode_check_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -8070,6 +8096,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15063,
       "name": "__results_durations_stats_taskruns__build_sast_unicode_check_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -8086,6 +8113,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15065,
       "name": "__results_durations_stats_taskruns__build_sast_unicode_check_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -8102,6 +8130,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15066,
       "name": "__results_durations_stats_taskruns__build_sast_unicode_check_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -8118,6 +8147,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15067,
       "name": "__results_durations_stats_taskruns__build_sast_unicode_check_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -8219,6 +8249,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15069,
       "name": "__results_durations_stats_taskruns__build_source_build_oci_ta__passed_duration_mean",
       "extractors": [
         {
@@ -8235,6 +8266,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15068,
       "name": "__results_durations_stats_taskruns__build_source_build_oci_ta__passed_duration_samples",
       "extractors": [
         {
@@ -8251,6 +8283,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15070,
       "name": "__results_durations_stats_taskruns__build_source_build_oci_ta__passed_idle_mean",
       "extractors": [
         {
@@ -8267,6 +8300,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15071,
       "name": "__results_durations_stats_taskruns__build_source_build_oci_ta__passed_running_mean",
       "extractors": [
         {
@@ -8283,6 +8317,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15072,
       "name": "__results_durations_stats_taskruns__build_source_build_oci_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -8384,6 +8419,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15074,
       "name": "__results_durations_stats_taskruns__managed_collect_data__passed_duration_mean",
       "extractors": [
         {
@@ -8400,6 +8436,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15073,
       "name": "__results_durations_stats_taskruns__managed_collect_data__passed_duration_samples",
       "extractors": [
         {
@@ -8416,6 +8453,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15075,
       "name": "__results_durations_stats_taskruns__managed_collect_data__passed_idle_mean",
       "extractors": [
         {
@@ -8432,6 +8470,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15076,
       "name": "__results_durations_stats_taskruns__managed_collect_data__passed_running_mean",
       "extractors": [
         {
@@ -8448,6 +8487,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15077,
       "name": "__results_durations_stats_taskruns__managed_collect_data__passed_scheduled_mean",
       "extractors": [
         {
@@ -8464,6 +8504,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15079,
       "name": "__results_durations_stats_taskruns__managed_verify_conforma_konflux_ta__passed_duration_mean",
       "extractors": [
         {
@@ -8480,6 +8521,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15078,
       "name": "__results_durations_stats_taskruns__managed_verify_conforma_konflux_ta__passed_duration_samples",
       "extractors": [
         {
@@ -8496,6 +8538,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15080,
       "name": "__results_durations_stats_taskruns__managed_verify_conforma_konflux_ta__passed_idle_mean",
       "extractors": [
         {
@@ -8512,6 +8555,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15081,
       "name": "__results_durations_stats_taskruns__managed_verify_conforma_konflux_ta__passed_running_mean",
       "extractors": [
         {
@@ -8528,6 +8572,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15082,
       "name": "__results_durations_stats_taskruns__managed_verify_conforma_konflux_ta__passed_scheduled_mean",
       "extractors": [
         {
@@ -8629,6 +8674,7 @@
     {
       "access": "PUBLIC",
       "owner": "hybrid-cloud-experience-perfscale-team",
+      "id": 15226,
       "name": "__results_errors_error_caused_by_simple",
       "extractors": [
         {
@@ -8637,7 +8683,6 @@
           "isarray": false
         }
       ],
-      "_function": "",
       "filtering": false,
       "metrics": true,
       "schemaId": 169
@@ -9438,6 +9483,5 @@
       "metrics": true,
       "schemaId": 169
     }
-  ],
-  "transformers": []
+  ]
 }


### PR DESCRIPTION
## Why

Part 2 after [PR #122](https://github.com/jhutar/e2e-tests/pull/122): keep `horreum-schema.json` aligned with **Horreum schema 169** as actually imported (`try01_import_20260408_rhtap-perf-test_schema_for_load-tests.json` via `PUT /api/schema/import`), using the **same** label ordering as the sort-only PR (alphabetical by `name`, documented in `tests/load-tests/ci-scripts/config/README.md`).

## What

- Update **`tests/load-tests/ci-scripts/config/horreum-schema.json`** from **try01**, **sorted by `name`**.
- Diff vs current `fix45-probes` is intentionally small: mainly **Horreum-assigned `id`** fields for labels that were added without ids in git before import; **no** changes to label **names** or **extractors** relative to the sorted baseline.

## How to verify

- `git diff jhutar/fix45-probes -- tests/load-tests/ci-scripts/config/horreum-schema.json` should show only the expected **`id`** updates (and minimal related churn).